### PR TITLE
Corrected the tests for them to work.

### DIFF
--- a/debug_toolbar_htmltidy/tests/tests.py
+++ b/debug_toolbar_htmltidy/tests/tests.py
@@ -6,6 +6,8 @@ from django.test import TestCase
 
 from dingus import Dingus
 
+import os
+
 
 class Settings(object):
     """Allows you to define settings that are required
@@ -34,6 +36,11 @@ class BaseTestCase(TestCase):
     def setUp(self):
         settings.DEBUG = True
         settings.DEBUG_TOOLBAR_PANELS = self.panels_list
+        settings.TEMPLATE_DIRS = (
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    'templates/'),
+                )
 
         request = Dingus('request')
         toolbar = DebugToolbar(request)


### PR DESCRIPTION
Tests are not functionning because the tests cannot find the htmlvalidator template.

Also more warnings are found than in the previous version
