### PR TITLE
Testfix: middleware should be deactivated while running the tests

### DIFF
--- a/debug_toolbar_htmltidy/tests/tests.py
+++ b/debug_toolbar_htmltidy/tests/tests.py
@@ -41,6 +41,7 @@ class BaseTestCase(TestCase):
                     os.path.dirname(os.path.abspath(__file__)),
                     'templates/'),
                 )
+        settings.MIDDLEWARE_CLASSES = ()
 
         request = Dingus('request')
         toolbar = DebugToolbar(request)

--- a/debug_toolbar_htmltidy/tests/tests.py
+++ b/debug_toolbar_htmltidy/tests/tests.py
@@ -41,7 +41,11 @@ class BaseTestCase(TestCase):
                     os.path.dirname(os.path.abspath(__file__)),
                     'templates/'),
                 )
-        settings.MIDDLEWARE_CLASSES = ()
+        settings.MIDDLEWARE_CLASSES = (
+            'django.middleware.common.CommonMiddleware',
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+        )
 
         request = Dingus('request')
         toolbar = DebugToolbar(request)


### PR DESCRIPTION
Here is the problem, when you run 

example_htmltidy/manage.py test

Test fails because of too many errors. This is because the example app installs the middlewares which get to run before the htmltidy can check the validity of the page, and causes too many warnings.

Fix: empty the MIDDLEWARE_CLASSES settings before running the tests
